### PR TITLE
Add protag field to Locations responce

### DIFF
--- a/common/data_access.go
+++ b/common/data_access.go
@@ -65,7 +65,8 @@ func GetLocations(gameParams GameParams, wikiConfig setup.WikiConfig) (locations
 	}
 
 	locations = &Locations{
-		Game: gameParams.GameCode,
+		Game:   gameParams.GameCode,
+		Protag: gameParams.Protag,
 	}
 
 	protagCategory := ""
@@ -132,6 +133,10 @@ func GetLocations(gameParams GameParams, wikiConfig setup.WikiConfig) (locations
 			location, err := processLocation(game.Name, value)
 			if err != nil {
 				return locations, err
+			}
+
+			if gameParams.Protag != "" {
+				location.Protags = []string{gameParams.Protag}
 			}
 
 			locations.Locations = append(locations.Locations, location)

--- a/common/data_access.go
+++ b/common/data_access.go
@@ -65,8 +65,7 @@ func GetLocations(gameParams GameParams, wikiConfig setup.WikiConfig) (locations
 	}
 
 	locations = &Locations{
-		Game:   gameParams.GameCode,
-		Protag: gameParams.Protag,
+		Game: gameParams.GameCode,
 	}
 
 	protagCategory := ""

--- a/common/data_access.go
+++ b/common/data_access.go
@@ -61,11 +61,23 @@ func GetLocations(gameParams GameParams, wikiConfig setup.WikiConfig) (locations
 		for protag := range protagCategories {
 			acceptedProtags = append(acceptedProtags, protag)
 		}
-		return locations, fmt.Errorf("game has multiple protagonists, please specify one (accepted values are: %v)", acceptedProtags)
+		locations = &Locations{
+			Game:    gameParams.GameCode,
+			Protags: acceptedProtags,
+		}
+		return locations, nil
+	}
+
+	var responseProtags []string
+	if hasMultipleProtags && gameParams.Protag != "" {
+		responseProtags = []string{gameParams.Protag}
+	} else if !hasMultipleProtags {
+		responseProtags = []string{}
 	}
 
 	locations = &Locations{
-		Game: gameParams.GameCode,
+		Game:    gameParams.GameCode,
+		Protags: responseProtags,
 	}
 
 	protagCategory := ""

--- a/common/structures.go
+++ b/common/structures.go
@@ -24,7 +24,6 @@ type Location struct {
 type Locations struct {
 	Locations   []*Location `json:"locations"`
 	Game        string      `json:"game"`
-	Protag      string      `json:"protag,omitempty"`
 	ContinueKey string      `json:"continueKey,omitempty"`
 }
 

--- a/common/structures.go
+++ b/common/structures.go
@@ -18,11 +18,13 @@ type Location struct {
 	VersionRemoved      string         `json:"versionRemoved,omitempty"`
 	VersionGaps         []string       `json:"versionGaps"`
 	MapIds              []int          `json:"mapIds"`
+	Protags             []string       `json:"protags,omitempty"`
 }
 
 type Locations struct {
 	Locations   []*Location `json:"locations"`
 	Game        string      `json:"game"`
+	Protag      string      `json:"protag,omitempty"`
 	ContinueKey string      `json:"continueKey,omitempty"`
 }
 

--- a/common/structures.go
+++ b/common/structures.go
@@ -24,6 +24,7 @@ type Location struct {
 type Locations struct {
 	Locations   []*Location `json:"locations"`
 	Game        string      `json:"game"`
+	Protags     []string    `json:"protags,omitempty"`
 	ContinueKey string      `json:"continueKey,omitempty"`
 }
 


### PR DESCRIPTION
Populate protags array in Location response when protag parameter is specified

For multi-protagonist games, querying without specifying a protagonist will return a list of protagonist names
